### PR TITLE
Ruff suggested fixes

### DIFF
--- a/core/dungeonworld_grid.py
+++ b/core/dungeonworld_grid.py
@@ -132,7 +132,7 @@ class MazeGrid:
         for i in range(self.width):
             for j in range(self.height):
                 maze_object = self.get(i, j)
-                if maze_object == None:
+                if maze_object is None:
                     array[i,j] = self.OBJECT_TO_IDX['empty']
                 else:
                     array[i,j] = self.OBJECT_TO_IDX[maze_object.type]

--- a/envs/simple_dungeonworld_env.py
+++ b/envs/simple_dungeonworld_env.py
@@ -104,7 +104,7 @@ class DungeonMazeEnv(gym.Env):
         # Get the contents of the cell in front of the agent
         cell_in_front = self.maze.get(*position_in_front)
 
-        if cell_in_front == None:
+        if cell_in_front is None:
             # if nothing in front return a white image
             return np.ones((20,20))*255
         else:
@@ -154,7 +154,7 @@ class DungeonMazeEnv(gym.Env):
             if self.robot_direction > 3:
                 self.robot_direction -= 4
         elif action == Actions.forwards:
-            if cell_in_front == None or cell_in_front.can_overlap():
+            if cell_in_front is None or cell_in_front.can_overlap():
                 self.robot_position = position_in_front
             else:
                 # Terminate with penalty as robot tried to crash into an object in the cell in front.
@@ -208,7 +208,7 @@ class DungeonMazeEnv(gym.Env):
 
         # Add the walls
         for cell in self.maze.grid:
-            if cell != None and cell.type == 'wall':
+            if cell is not None and cell.type == 'wall':
                 pygame.draw.rect(
                     canvas,
                     (0, 0, 0),

--- a/manual_control.py
+++ b/manual_control.py
@@ -1,5 +1,4 @@
 from envs.simple_dungeonworld_env import DungeonMazeEnv
-import numpy as np
 
 SIZE=8
 


### PR DESCRIPTION
Removes an unused import and replaces comparisons (`==` or `!=`) with None, with `is` or `is not` respectively.
This is more precise, as for example:
```python
0 == None # True
[] == None # True
None == None # True
```
Whereas:
```python
0 is None # False
[] is None # False
None is None # True
```